### PR TITLE
Build supported Ubuntu versions in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("rd-apmm-groovy-ci-library@samn-multiple-ubuntus") _
+@Library("rd-apmm-groovy-ci-library@v1.x") _
 
 /*
  Runs the following steps in parallel and reports results to GitHub:


### PR DESCRIPTION
Dynamically build for trusty and xenial in parallel, taking the list of distributions to use from the shared library.

Deltas after #7 https://github.com/bbc/rd-apmm-python-lib-mediatimestamp/compare/jamesba-jenkinsfile-pbuild...samn-jenkins-multideb?expand=1
