### PR TITLE
timerange equality handles start and end None case

### DIFF
--- a/mediatimestamp/__init__.py
+++ b/mediatimestamp/__init__.py
@@ -855,10 +855,14 @@ class TimeRange (object):
     def __eq__(self, other):
         return ((self.is_empty() and other.is_empty()) or
                 (((self.start is None and other.start is None) or
-                  (self.start == other.start and
+                  (self.start is not None and
+                   other.start is not None and
+                   self.start == other.start and
                    (self.inclusivity & TimeRange.INCLUDE_START) == (other.inclusivity & TimeRange.INCLUDE_START))) and
                  ((self.end is None and other.end is None) or
-                  (self.end == other.end and
+                  (self.end is not None and
+                   other.end is not None and
+                   self.end == other.end and
                    (self.inclusivity & TimeRange.INCLUDE_END) == (other.inclusivity & TimeRange.INCLUDE_END)))))
 
     def contains_subrange(self, tr):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.0.0-dev2'
+version = '1.0.0-dev3'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'


### PR DESCRIPTION
The issue arose when comparing a time range with a TimeRange.eternity() where the eternity has None for start and end values.

I'm not sure whether the package version change is correct and no changelog entry.