### PR TITLE
Add a note about seconds:nanoseconds not seconds.fractions to docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mediatimestamp Changelog
 
+## 1.0.2
+- Updated docstrings to note that "seconds:nanoseconds" is preferred over
+  "seconds.fraction".
+
 ## 1.0.1
 - Added `MAX_NANOSEC` and `MAX_SECONDS` to `TimeOffset`
 

--- a/mediatimestamp/__init__.py
+++ b/mediatimestamp/__init__.py
@@ -132,7 +132,12 @@ def _parse_iso8601(iso8601):
 
 
 class TimeOffset(object):
-    """A nanosecond precision time difference object."""
+    """A nanosecond precision time difference object.
+
+    Note that the canonical representation of a TimeOffset is seconds:nanoseconds, e.g. "4:500000000".
+    TimeOffsets in seconds.fractions format (e.g. "4.5") can be parsed, but should not be used for serialization or
+    storage due to difficulty disambiguating them from floats.
+    """
     ROUND_DOWN = 0
     ROUND_NEAREST = 1
     ROUND_UP = 2
@@ -193,6 +198,10 @@ class TimeOffset(object):
 
     @classmethod
     def from_str(cls, toff_str):
+        """Parse a string as a TimeOffset
+
+        Accepts both second:nanosecond and second.fraction formats.
+        """
         if '.' in toff_str:
             return cls.from_sec_frac(toff_str)
         else:

--- a/mediatimestamp/__init__.py
+++ b/mediatimestamp/__init__.py
@@ -582,6 +582,11 @@ class Timestamp(TimeOffset):
 
     @classmethod
     def from_str(cls, ts_str, force_pure_python=False):
+        """Parse a string as a TimeStamp
+
+        Accepts SMPTE timelabel, ISO 8601 UTC, second:nanosecond and second.fraction formats, along with "now" to mean
+        the current time.
+        """
         if 'F' in ts_str:
             return cls.from_smpte_timelabel(ts_str)
         elif 'T' in ts_str:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.0.1'
+version = '1.0.2'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'


### PR DESCRIPTION
The seconds:nanonseconds form of representing a `TimeOffset` (and descendants) is preferred for storage and serialization (e.g. in JSON) because it is more readily disambiguated from other float values.

This updates the documentation to note that.

See also discussion on https://github.com/bbc/rd-apmm-python-lib-mediajson/pull/6