### PR TITLE
 Remove install command, build nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # mediatimestamp Changelog
 
+## 1.1.3
+- Remove unused custom install command from tox.ini.
+- Add Jenkins build trigger to rebuild master every day.
+- Allow build to run on a wider variety of slaves.
+
 ## 1.1.2
 - BUGFIX: upload all pydocs
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@
 
 pipeline {
     agent {
-        label "16.04&&ipstudio-deps"
+        label "ubuntu&&apmm-slave"
     }
     options {
         ansiColor('xterm') // Add support for coloured output

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,9 @@ pipeline {
         ansiColor('xterm') // Add support for coloured output
         buildDiscarder(logRotator(numToKeepStr: '10')) // Discard old builds
     }
+    triggers {
+        cron(env.BRANCH_NAME == 'master' ? 'H H(0-8) * * *' : '') // Build master some time every morning
+    }
     parameters {
         booleanParam(name: "FORCE_PYUPLOAD", defaultValue: false, description: "Force Python artifact upload")
         booleanParam(name: "FORCE_DEBUPLOAD", defaultValue: false, description: "Force Debian package upload")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.1.2'
+version = '1.1.3'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,4 @@ deps =
     nose2
     mock
     hypothesis
-install_command = pip install --process-dependency-links {opts} {packages}
 


### PR DESCRIPTION
Removes the --process-dependency-links flag from tox.ini's install_command, which has been deprecated for some time and now been removed. As a result our install_command is the default, so the entire option has been removed.
Also adds a trigger to build master overnight.