### PR TITLE
Add normalise method to immutable.TimeRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediatimestamp Changelog
 
+## 1.5.0
+- Added normalisation function for immutable.TimeRange
+
 ## 1.4.0
 - Added richer comparison functions for immutable.TimeRange
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.4.0'
+version = '1.5.0'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1438,6 +1438,18 @@ class TestTimeRange (unittest.TestCase):
              TimeRange.from_str("[0:40000000_")),
             (TimeRange.from_str("_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
              TimeRange.from_str("_1:0)")),
+            (TimeRange.from_str("[0:10000000_1:0)"), Fraction(25, 1), TimeRange.PRESERVE_START,
+             TimeRange.from_str("[0:10000000_1:10000000)")),
+            (TimeRange.from_str("[0:10000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_START,
+             TimeRange.from_str("[0:10000000_1:10000000)")),
+            (TimeRange.from_str("(0:10000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_START,
+             TimeRange.from_str("[0:50000000_1:10000000)")),
+            (TimeRange.from_str("[0:10000000_1:0)"), Fraction(25, 1), TimeRange.PRESERVE_END,
+             TimeRange.from_str("[0:0_1:0)")),
+            (TimeRange.from_str("[0:00000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_END,
+             TimeRange.from_str("[0:10000000_1:10000000)")),
+            (TimeRange.from_str("(0:00000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_END,
+             TimeRange.from_str("[0:50000000_1:10000000)")),
         ]
 
         for (tr, rate, rounding, expected) in tests_tr:

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -20,6 +20,7 @@ import contextlib
 
 from datetime import datetime
 from dateutil import tz
+from fractions import Fraction
 
 from copy import deepcopy
 
@@ -1392,3 +1393,56 @@ class TestTimeRange (unittest.TestCase):
             with self.subTest(tr=tr, ts=ts):
                 with self.assertRaises(ValueError):
                     tr.split_at(ts)
+
+    def test_normalise(self):
+        tests_tr = [
+            (TimeRange.from_str("[0:0_1:0)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:0_1:0)")),
+            (TimeRange.from_str("[0:0_1:0]"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:0_1:40000000)")),
+            (TimeRange.from_str("(0:0_1:0)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:40000000_1:0)")),
+            (TimeRange.from_str("(0:0_1:0]"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:40000000_1:40000000)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:0_1:0)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_DOWN,
+             TimeRange.from_str("[0:0_0:960000000)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_UP,
+             TimeRange.from_str("[0:40000000_1:0)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_IN,
+             TimeRange.from_str("[0:40000000_0:960000000)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_OUT,
+             TimeRange.from_str("[0:0_1:0)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_START,
+             TimeRange.from_str("[0:0_0:960000000)")),
+            (TimeRange.from_str("[0:10000000_0:999999999)"), Fraction(25, 1), TimeRange.ROUND_END,
+             TimeRange.from_str("[0:40000000_1:0)")),
+            (TimeRange.from_str("(0:10000000_0:999999999]"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:40000000_1:40000000)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:40000000_1:0)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_UP,
+             TimeRange.from_str("[0:40000000_1:40000000)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_DOWN,
+             TimeRange.from_str("[0:0_1:0)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_IN,
+             TimeRange.from_str("[0:40000000_1:0)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_OUT,
+             TimeRange.from_str("[0:0_1:40000000)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_START,
+             TimeRange.from_str("[0:40000000_1:40000000)")),
+            (TimeRange.from_str("[0:39999999_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_END,
+             TimeRange.from_str("[0:0_1:0)")),
+            (TimeRange.from_str("[0:39999999_"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[0:40000000_")),
+            (TimeRange.from_str("_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("_1:0)")),
+        ]
+
+        for (tr, rate, rounding, expected) in tests_tr:
+            with self.subTest(tr=tr, rate=rate, expected=expected):
+                result = tr.normalise(rate.numerator, rate.denominator, rounding=rounding)
+                self.assertEqual(result, expected,
+                                 msg=("{!r}.normalise({}, {}, rounding={}) == {!r}, expected {!r}"
+                                      .format(tr, rate.numerator, rate.denominator, rounding, result, expected)))


### PR DESCRIPTION
This is a relatively fully capable normalisation mechanism for ranges similar to what already exists for timestamps