### PR TITLE
Fixed bug that caused incorrect normalisation on some timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   previously been seen because there was no test coverage for
   non-nearest rounding and none of our tests used rates with prime
   denominators other than 2.
+- Switched test runner in tox from nose2 to unittest
 
 ## 1.5.0
 - Added normalisation function for immutable.TimeRange

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # mediatimestamp Changelog
 
+## 1.5.1
+- Fixed bug in `TimeOffset.to_count` (both versions) that caused
+  incorrect results when rounding down when the denominator of the
+  rate properly divided neither the seconds part nor the nanoseconds
+  part of the timestamp, nor the number of nanoseconds in a second,
+  but did properly divide the whole timestamp expressed in
+  nanoseconds. This bug has been present for some time but had not
+  previously been seen because there was no test coverage for
+  non-nearest rounding and none of our tests used rates with prime
+  denominators other than 2.
+
 ## 1.5.0
 - Added normalisation function for immutable.TimeRange
 

--- a/mediatimestamp/immutable.py
+++ b/mediatimestamp/immutable.py
@@ -285,10 +285,12 @@ class TimeOffset(BaseTimeOffset):
         #             = (off_sec x rate_num / rate_den) + (off_nsec x rate_num) / rate_den)
         #             = {f1} + {f2}
         # reduce {f1} as follows: a*b/c = ((a/c)*c + a%c) * b) / c = (a/c)*b + (a%c)*b/c
+        # then combine the f1 and f2 nanosecond values before division by rate_den to avoid loss of precision when
+        # off_sec and off_nsec are not multiples of rate_den, but (off_sec + off_nsec) is
         f1_whole = (abs_off.sec // rate_den) * rate_num
-        f1_nsec = (abs_off.sec % rate_den) * rate_num * self.MAX_NANOSEC // rate_den
-        f2_nsec = abs_off.ns * rate_num // rate_den
-        return self.sign * (f1_whole + (f1_nsec + f2_nsec) // self.MAX_NANOSEC)
+        f1_dennsec = (abs_off.sec % rate_den) * rate_num * self.MAX_NANOSEC
+        f2_dennsec = abs_off.ns * rate_num
+        return self.sign * (f1_whole + (f1_dennsec + f2_dennsec) // (rate_den * self.MAX_NANOSEC))
 
     def to_phase_offset(self, rate_num, rate_den=1):
         """Return the smallest positive TimeOffset such that abs(self - returnval) represents an integer number of

--- a/mediatimestamp/mutable.py
+++ b/mediatimestamp/mutable.py
@@ -251,10 +251,12 @@ class TimeOffset(BaseTimeOffset):
         #             = (off_sec x rate_num / rate_den) + (off_nsec x rate_num) / rate_den)
         #             = {f1} + {f2}
         # reduce {f1} as follows: a*b/c = ((a/c)*c + a%c) * b) / c = (a/c)*b + (a%c)*b/c
+        # then combine the f1 and f2 nanosecond values before division by rate_den to avoid loss of precision when
+        # off_sec and off_nsec are not multiples of rate_den, but (off_sec + off_nsec) is
         f1_whole = (abs_off.sec // rate_den) * rate_num
-        f1_nsec = (abs_off.sec % rate_den) * rate_num * self.MAX_NANOSEC // rate_den
-        f2_nsec = abs_off.ns * rate_num // rate_den
-        return self.sign * (f1_whole + (f1_nsec + f2_nsec) // self.MAX_NANOSEC)
+        f1_dennsec = (abs_off.sec % rate_den) * rate_num * self.MAX_NANOSEC
+        f2_dennsec = abs_off.ns * rate_num
+        return self.sign * (f1_whole + (f1_dennsec + f2_dennsec) // (rate_den * self.MAX_NANOSEC))
 
     def to_millisec(self, rounding=ROUND_NEAREST):
         use_rounding = rounding

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.5.0'
+version = '1.5.1'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -60,21 +60,62 @@ class TestTimeOffset(unittest.TestCase):
 
     def test_normalise(self):
         tests_ts = [
-            (TimeOffset(0, 0), (30000, 1001), TimeOffset(0, 0)),
-            (TimeOffset(1001, 0), (30000, 1001), TimeOffset(1001, 0)),
-            (TimeOffset(1001, 1001.0/30000/2*1000000000), (30000, 1001), TimeOffset(1001, 0)),
-            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1), (30000, 1001), TimeOffset(1001, 1001.0/30000*1000000000)),
-            (TimeOffset(1001, 1001.0/30000/2*1000000000, -1), (30000, 1001), TimeOffset(1001, 0, -1)),
-            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1, -1), (30000, 1001),
-             TimeOffset(1001, 1001.0/30000*1000000000, -1))
+            (TimeOffset(0, 0), Fraction(30000, 1001), TimeOffset.ROUND_NEAREST,
+             TimeOffset(0, 0)),
+            (TimeOffset(1001, 0), Fraction(30000, 1001), TimeOffset.ROUND_NEAREST,
+             TimeOffset(1001, 0)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000), Fraction(30000, 1001), TimeOffset.ROUND_NEAREST,
+             TimeOffset(1001, 0)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1), Fraction(30000, 1001), TimeOffset.ROUND_NEAREST,
+             TimeOffset(1001, 1001.0/30000*1000000000)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000, -1), Fraction(30000, 1001), TimeOffset.ROUND_NEAREST,
+             TimeOffset(1001, 0, -1)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1, -1), Fraction(30000, 1001), TimeOffset.ROUND_NEAREST,
+             TimeOffset(1001, 1001.0/30000*1000000000, -1)),
+            (TimeOffset(1521731233, 320000000), Fraction(25, 3), TimeOffset.ROUND_NEAREST,
+             TimeOffset(1521731233, 320000000)),
+            (TimeOffset(0, 0), Fraction(30000, 1001), TimeOffset.ROUND_UP,
+             TimeOffset(0, 0)),
+            (TimeOffset(1001, 0), Fraction(30000, 1001), TimeOffset.ROUND_UP,
+             TimeOffset(1001, 0)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000), Fraction(30000, 1001), TimeOffset.ROUND_UP,
+             TimeOffset(1001, 1001.0/30000*1000000000)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1), Fraction(30000, 1001), TimeOffset.ROUND_UP,
+             TimeOffset(1001, 1001.0/30000*1000000000)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000, -1), Fraction(30000, 1001), TimeOffset.ROUND_UP,
+             TimeOffset(1001, 0, -1)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1, -1), Fraction(30000, 1001), TimeOffset.ROUND_UP,
+             TimeOffset(1001, 0, -1)),
+            (TimeOffset(1521731233, 320000000), Fraction(25, 3), TimeOffset.ROUND_UP,
+             TimeOffset(1521731233, 320000000)),
+            (TimeOffset(0, 0), Fraction(30000, 1001), TimeOffset.ROUND_DOWN,
+             TimeOffset(0, 0)),
+            (TimeOffset(1001, 0), Fraction(30000, 1001), TimeOffset.ROUND_DOWN,
+             TimeOffset(1001, 0)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000), Fraction(30000, 1001), TimeOffset.ROUND_DOWN,
+             TimeOffset(1001, 0)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1), Fraction(30000, 1001), TimeOffset.ROUND_DOWN,
+             TimeOffset(1001, 0)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000, -1), Fraction(30000, 1001), TimeOffset.ROUND_DOWN,
+             TimeOffset(1001, 1001.0/30000*1000000000, -1)),
+            (TimeOffset(1001, 1001.0/30000/2*1000000000 + 1, -1), Fraction(30000, 1001), TimeOffset.ROUND_DOWN,
+             TimeOffset(1001, 1001.0/30000*1000000000, -1)),
+            (TimeOffset(1521731233, 320000000), Fraction(25, 3), TimeOffset.ROUND_DOWN,
+             TimeOffset(1521731233, 320000000)),
         ]
 
-        for t in tests_ts:
-            with self.subTest(t=t):
-                r = t[0].normalise(t[1][0], t[1][1])
-                self.assertEqual(r, t[2],
-                                 msg=("{!r}.normalise({}, {}) == {!r}, expected {!r}"
-                                      .format(t[0], t[1][0], t[1][1], r, t[2])))
+        n = 0
+        for (input, rate, rounding, expected) in tests_ts:
+            with self.subTest(test_data_index=n,
+                              input=input,
+                              rate=rate,
+                              rounding=rounding,
+                              expected=expected):
+                n += 1
+                r = input.normalise(rate.numerator, rate.denominator, rounding=rounding)
+                self.assertEqual(r, expected,
+                                 msg=("{!r}.normalise({}, {}, rounding={}) == {!r}, expected {!r}"
+                                      .format(input, rate.numerator, rate.denominator, rounding, r, expected)))
 
     def test_hash(self):
         self.assertEqual(hash(TimeOffset(0, 0)), hash(TimeOffset(0, 0)))

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -106,6 +106,10 @@ class TestTimeOffset(unittest.TestCase):
 
         n = 0
         for (input, rate, rounding, expected) in tests_ts:
+            # Nb. subTest will add a printout of all its kwargs to any error message generated
+            # by a failure within it. The variable n is being used here to ensure that the index
+            # of the current test within tests_ts is printed on any failure. (Nb. only works with
+            # python3 unittest test runner)
             with self.subTest(test_data_index=n,
                               input=input,
                               rate=rate,

--- a/tests/test_mutable.py
+++ b/tests/test_mutable.py
@@ -24,9 +24,11 @@ from fractions import Fraction
 
 from mediatimestamp.mutable import Timestamp, TimeOffset, TsValueError, TimeRange
 
+
 @contextlib.contextmanager
 def dummysubtest(*args, **kwargs):
     yield None
+
 
 if PY2:
     BUILTINS = "__builtin__"

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,8 @@
 envlist = py27, py3
 
 [testenv]
-commands = nose2 --with-coverage --coverage-report=annotate --coverage-report=term --coverage=mediatimestamp
+commands = python -m unittest discover -s tests
 deps =
-    nose2
     mock
     hypothesis
 


### PR DESCRIPTION
Fixed bug in `TimeOffset.to_count` (both versions) that caused
incorrect results when rounding down when the denominator of the
rate properly divided neither the seconds part nor the nanoseconds
part of the timestamp, nor the number of nanoseconds in a second,
but did properly divide the whole timestamp expressed in
nanoseconds. This bug has been present for some time but had not
previously been seen because there was no test coverage for
non-nearest rounding and none of our tests used rates with prime
denominators other than 2.

https://www.pivotaltracker.com/story/show/164662206