### PR TITLE
[DO NOT MERGE] change timerange norm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mediatimestamp Changelog
 
+## 1.5.3
+- Change order of phase offset in TimeRange normalisation with
+PRESERVE_START/END to avoid rounding error causing an unexpected result.
+
 ## 1.5.2
 - Fixed bug in taking unions with empty ranges
 

--- a/mediatimestamp/immutable.py
+++ b/mediatimestamp/immutable.py
@@ -1240,19 +1240,24 @@ class TimeRange (BaseTimeRange):
             start_rounding = TimeRange.ROUND_NEAREST
             end_rounding = TimeRange.ROUND_NEAREST
         elif rounding in [TimeRange.PRESERVE_START, TimeRange.PRESERVE_END]:
-            start_rounding = TimeRange.ROUND_DOWN
-            end_rounding = TimeRange.ROUND_DOWN
+            start_rounding = TimeRange.ROUND_NEAREST
+            end_rounding = TimeRange.ROUND_NEAREST
         else:
             start_rounding = rounding
             end_rounding = rounding
 
+        if self.bounded_before() and rounding == TimeRange.PRESERVE_START:
+            phase_offset = self.start.to_phase_offset(rate_num, rate_den)
+        elif self.bounded_after() and rounding == TimeRange.PRESERVE_END:
+            phase_offset = self.end.to_phase_offset(rate_num, rate_den)
+
         if self.bounded_before():
-            start = self.start.to_count(rate_num, rate_den, start_rounding)
+            start = (self.start - phase_offset).to_count(rate_num, rate_den, start_rounding)
         else:
             start = None
 
         if self.bounded_after():
-            end = self.end.to_count(rate_num, rate_den, end_rounding)
+            end = (self.end - phase_offset).to_count(rate_num, rate_den, end_rounding)
         else:
             end = None
 
@@ -1266,11 +1271,6 @@ class TimeRange (BaseTimeRange):
                 start = self.start.to_count(rate_num, rate_den, TimeRange.ROUND_UP)
             else:
                 start = self.start.to_count(rate_num, rate_den, TimeRange.ROUND_DOWN)
-
-        if self.bounded_before() and rounding == TimeRange.PRESERVE_START:
-            phase_offset = self.start.to_phase_offset(rate_num, rate_den)
-        elif self.bounded_after() and rounding == TimeRange.PRESERVE_END:
-            phase_offset = self.end.to_phase_offset(rate_num, rate_den)
 
         if start is not None and not self.includes_start():
             start += 1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.5.2'
+version = '1.5.3'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1522,6 +1522,16 @@ class TestTimeRange (unittest.TestCase):
              TimeRange.from_str("[0:10000000_1:10000000)")),
             (TimeRange.from_str("(0:00000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_END,
              TimeRange.from_str("[0:50000000_1:10000000)")),
+            (TimeRange.from_str("[1537349337:0_1537349346:999979166]"), Fraction(48000, 1), TimeRange.ROUND_NEAREST,
+             TimeRange.from_str("[1537349337:0_1537349347:0)")),
+            (TimeRange.from_str("[1537349337:0_1537349346:999979166]"), Fraction(48000, 1), TimeRange.ROUND_UP,
+             TimeRange.from_str("[1537349337:0_1537349347:0)")),
+            (TimeRange.from_str("[1537349337:0_1537349346:999979166]"), Fraction(48000, 1), TimeRange.ROUND_DOWN,
+             TimeRange.from_str("[1537349337:0_1537349346:999979166)")),
+            (TimeRange.from_str("[1537349337:0_1537349346:999979166]"), Fraction(48000, 1), TimeRange.PRESERVE_START,
+             TimeRange.from_str("[1537349337:0_1537349347:0)")),
+            (TimeRange.from_str("[1537349337:0_1537349346:999979166]"), Fraction(48000, 1), TimeRange.PRESERVE_END,
+             TimeRange.from_str("[1537349336:999999999_1537349346:999999999)")),
         ]
 
         for (tr, rate, rounding, expected) in tests_tr:


### PR DESCRIPTION
I'm not sure about this change and therefore this PR is just for getting feedback.

This PR is a result of Squirrel returning an incorrect time range for a flow caused by < 1 ns representation error. The calculation in Squirrel is https://github.com/bbc/rd-cloudfit-squirrel-media-store/blob/master/src/serviceapi/squirrel_serviceapi/database.py#L267 and it returned `[1537349337:0_1537349346:999979166)` for the flow rather than `[1537349337:0_1537349347:0)`. The ideal end timestamp would be 1537349346:9999791666666666..., i.e. the Timestamp representation is below that.

See the tests for the different results you get with rounding.

This PR fixed that issue because it moves any representation errors into the phase offset value. However, note also how the representation error causes the result for `PRESERVE_END` to include a 1 nano second phase offset.

Regarding the Squirrel code, I'm not convinced that `PRESERVE_START` should be used because it complicates use of that time range when comparing for example because it includes a phase offset. The phase offset could be a representation error rather than a real offset. The phase offset could also be different if another start timestamp was used, e.g. if it was `1537349346:999979166`. 

