### PR TITLE
remove PRESERVE_START/END rounding options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediatimestamp Changelog
 
+## 1.6.0
+- Removed the PRESERVE_START and PRESERVE_END rounding options which are used in TimeRange.normalise().
+
 ## 1.5.2
 - Fixed bug in taking unions with empty ranges
 

--- a/mediatimestamp/immutable.py
+++ b/mediatimestamp/immutable.py
@@ -713,8 +713,6 @@ class TimeRange (BaseTimeRange):
     ROUND_OUT = 4
     ROUND_START = 5
     ROUND_END = 6
-    PRESERVE_START = 7
-    PRESERVE_END = 8
 
     def __init__(self, start, end, inclusivity=INCLUSIVE):
         """Construct a time range starting at start and ending at end
@@ -1225,10 +1223,6 @@ class TimeRange (BaseTimeRange):
                          as the start
         * ROUND_END -- The end rounds to the nearest normalised timestamp, the start rounds in the same direction
                        as the end
-        * PRESERVE_START -- The start is not rounded at all, the end is adjusted to match its phase offset
-                            (and the phase_offset parameter will be ignored)
-        * PRESERVE_END -- The end is not rounded at all, the start is adjusted to match its phase offset
-                          (and the phase_offset parameter will be ignored)
         """
         if rounding == TimeRange.ROUND_OUT:
             start_rounding = TimeRange.ROUND_DOWN
@@ -1239,9 +1233,6 @@ class TimeRange (BaseTimeRange):
         elif rounding in [TimeRange.ROUND_START, TimeRange.ROUND_END]:
             start_rounding = TimeRange.ROUND_NEAREST
             end_rounding = TimeRange.ROUND_NEAREST
-        elif rounding in [TimeRange.PRESERVE_START, TimeRange.PRESERVE_END]:
-            start_rounding = TimeRange.ROUND_DOWN
-            end_rounding = TimeRange.ROUND_DOWN
         else:
             start_rounding = rounding
             end_rounding = rounding
@@ -1267,20 +1258,15 @@ class TimeRange (BaseTimeRange):
             else:
                 start = self.start.to_count(rate_num, rate_den, TimeRange.ROUND_DOWN)
 
-        if self.bounded_before() and rounding == TimeRange.PRESERVE_START:
-            phase_offset = self.start.to_phase_offset(rate_num, rate_den)
-        elif self.bounded_after() and rounding == TimeRange.PRESERVE_END:
-            phase_offset = self.end.to_phase_offset(rate_num, rate_den)
-
         if start is not None and not self.includes_start():
             start += 1
         if end is not None and self.includes_end():
             end += 1
 
         if start is not None:
-            start = Timestamp.from_count(start, rate_num, rate_den) + phase_offset
+            start = Timestamp.from_count(start, rate_num, rate_den)
         if end is not None:
-            end = Timestamp.from_count(end, rate_num, rate_den) + phase_offset
+            end = Timestamp.from_count(end, rate_num, rate_den)
 
         return TimeRange(start,
                          end,

--- a/mediatimestamp/immutable.py
+++ b/mediatimestamp/immutable.py
@@ -1194,7 +1194,7 @@ class TimeRange (BaseTimeRange):
                 self.start == self.end and
                 self.inclusivity != TimeRange.INCLUSIVE)
 
-    def normalise(self, rate_num, rate_den=1, rounding=ROUND_NEAREST, phase_offset=TimeOffset()):
+    def normalise(self, rate_num, rate_den=1, rounding=ROUND_NEAREST):
         """Returns a normalised half-open TimeRange based on this timerange.
 
         The returned TimeRange will always have INCLUDE_START inclusivity.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.5.2'
+version = '1.6.0'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1510,18 +1510,6 @@ class TestTimeRange (unittest.TestCase):
              TimeRange.from_str("[0:40000000_")),
             (TimeRange.from_str("_1:10000000)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,
              TimeRange.from_str("_1:0)")),
-            (TimeRange.from_str("[0:10000000_1:0)"), Fraction(25, 1), TimeRange.PRESERVE_START,
-             TimeRange.from_str("[0:10000000_1:10000000)")),
-            (TimeRange.from_str("[0:10000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_START,
-             TimeRange.from_str("[0:10000000_1:10000000)")),
-            (TimeRange.from_str("(0:10000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_START,
-             TimeRange.from_str("[0:50000000_1:10000000)")),
-            (TimeRange.from_str("[0:10000000_1:0)"), Fraction(25, 1), TimeRange.PRESERVE_END,
-             TimeRange.from_str("[0:0_1:0)")),
-            (TimeRange.from_str("[0:00000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_END,
-             TimeRange.from_str("[0:10000000_1:10000000)")),
-            (TimeRange.from_str("(0:00000000_0:970000000]"), Fraction(25, 1), TimeRange.PRESERVE_END,
-             TimeRange.from_str("[0:50000000_1:10000000)")),
         ]
 
         for (tr, rate, rounding, expected) in tests_tr:


### PR DESCRIPTION
From discussion in https://github.com/bbc/rd-apmm-python-lib-mediatimestamp/pull/31.