### PR TITLE
add timerange encompass method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # mediatimestamp Changelog
 
+## 1.7.0
+- Added extend_to_encompass_timerange function for immutable.TimeRange.
+- Hardcode use of python3.4 in RPM spec file to workaround missing python3 soft
+link in recent (>3.4.9) centos python34 RPM.
+
 ## 1.6.0
 - Removed the PRESERVE_START and PRESERVE_END rounding options which are used in TimeRange.normalise().
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ deb: source deb_dist $(DEBIANOVERRIDES)
 $(RPM_PREFIX)/$(MODNAME).spec: rpm_spec
 
 rpm_spec: $(topdir)/setup.py
-	$(PYTHON3) $(topdir)/setup.py bdist_rpm $(RPM_PARAMS) --spec-only --dist-dir=$(RPM_PREFIX)
+	$(PYTHON3) $(topdir)/setup.py bdist_rpm $(RPM_PARAMS) --spec-only --dist-dir=$(RPM_PREFIX) --python=python3.4
 # END OF RPM SPEC RULES
 
 $(RPMBUILDDIRS):

--- a/mediatimestamp/immutable.py
+++ b/mediatimestamp/immutable.py
@@ -1124,6 +1124,10 @@ class TimeRange (BaseTimeRange):
         if not self.is_contiguous_with_timerange(other):
             raise ValueError("Timeranges {} and {} are not contiguous, so cannot take the union.".format(self, other))
 
+        return self.extend_to_encompass_timerange(other)
+
+    def extend_to_encompass_timerange(self, other):
+        """Returns the timerange that encompasses this and the other timerange."""
         if self.is_empty():
             return other
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.6.0'
+version = '1.7.0'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1519,7 +1519,7 @@ class TestTimeRange (unittest.TestCase):
                                  msg=("{!r}.normalise({}, {}, rounding={}) == {!r}, expected {!r}"
                                       .format(tr, rate.numerator, rate.denominator, rounding, result, expected)))
 
-    def test_union(self):
+    def test_extend_to_encompass(self):
         test_data = [
             (TimeRange.from_str("()"), TimeRange.from_str("()"),
              TimeRange.from_str("()")),
@@ -1545,15 +1545,35 @@ class TestTimeRange (unittest.TestCase):
              TimeRange.from_str("[5:0_15:0)")),
             (TimeRange.from_str("()"), TimeRange.from_str("_15:0)"),
              TimeRange.from_str("_15:0)")),
+
+            # discontiguous
+            (TimeRange.from_str("_0:0)"), TimeRange.from_str("(0:0_"),
+             TimeRange.from_str("_")),
+            (TimeRange.from_str("(0:0_"), TimeRange.from_str("_0:0)"),
+             TimeRange.from_str("_")),
+            (TimeRange.from_str("[0:0_5:0)"), TimeRange.from_str("(5:0_15:0)"),
+             TimeRange.from_str("[0:0_15:0)")),
+            (TimeRange.from_str("(5:0_15:0)"), TimeRange.from_str("[0:0_5:0)"),
+             TimeRange.from_str("[0:0_15:0)")),
+            (TimeRange.from_str("[0:0_5:0)"), TimeRange.from_str("[10:0_15:0)"),
+             TimeRange.from_str("[0:0_15:0)")),
+            (TimeRange.from_str("[10:0_15:0)"), TimeRange.from_str("[0:0_5:0)"),
+             TimeRange.from_str("[0:0_15:0)")),
         ]
 
         for (first, second, expected) in test_data:
             with self.subTest(first=first, second=second, expected=expected):
-                self.assertEqual(first.union_with_timerange(second), expected)
+                self.assertEqual(first.extend_to_encompass_timerange(second), expected)
 
+    def test_union_raises(self):
+        # discontiguous part of test_extend_to_encompass raises for a union
         test_data = [
             (TimeRange.from_str("_0:0)"), TimeRange.from_str("(0:0_")),
+            (TimeRange.from_str("(0:0_"), TimeRange.from_str("_0:0)")),
+            (TimeRange.from_str("[0:0_5:0)"), TimeRange.from_str("(5:0_15:0)")),
+            (TimeRange.from_str("(5:0_15:0)"), TimeRange.from_str("[0:0_5:0)")),
             (TimeRange.from_str("[0:0_5:0)"), TimeRange.from_str("[10:0_15:0)")),
+            (TimeRange.from_str("[10:0_15:0)"), TimeRange.from_str("[0:0_5:0)")),
         ]
 
         for (first, second) in test_data:


### PR DESCRIPTION
This is needed to allow combination of time ranges that are not contiguous.

Pivotal: https://www.pivotaltracker.com/story/show/165214319