### PR TITLE
Cap python-dateutil version to manage botocore version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ package_names = packages.keys()
 
 # This is where you list packages which are required
 packages_required = [
-    "python-dateutil>=2.4.2",
+    "python-dateutil>=2.1,<2.8.1",
     "six>=1.10.0",
 ]
 


### PR DESCRIPTION
Response to https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9