### PR TITLE
Version 1.7.2: Normalise timerange never and eternity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # mediatimestamp Changelog
 
+## 1.7.3
+- Normalise time ranges where start > end to equal TimeRange.never().
+- Normalise inclusivity for unbounded time ranges to equal TimeRange.eternity().
+
 ## 1.7.2
 - Require Python version 3.6 rather than 3.
 

--- a/mediatimestamp/immutable.py
+++ b/mediatimestamp/immutable.py
@@ -720,6 +720,17 @@ class TimeRange (BaseTimeRange):
         :param start: A Timestamp or None
         :param end: A Timestamp or None
         :param inclusivity: a combination of flags INCLUDE_START and INCLUDE_END"""
+        # Normalise the 'never' cases
+        if start is not None and end is not None:
+            if start > end or (start == end and inclusivity != TimeRange.INCLUSIVE):
+                start = Timestamp()
+                end = Timestamp()
+                inclusivity = TimeRange.EXCLUSIVE
+
+        # Normalise the 'eternity' cases
+        if start is None and end is None:
+            inclusivity = TimeRange.INCLUSIVE
+
         super(TimeRange, self).__init__(start, end, inclusivity)
 
     def __setattr__(self, name, value):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.7.2'
+version = '1.7.3'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1599,3 +1599,22 @@ class TestTimeRange (unittest.TestCase):
             with self.subTest(first=first, second=second):
                 with self.assertRaises(ValueError):
                     first.union_with_timerange(second)
+
+    def test_never_normalise(self):
+        """Check 'never' (empty) normalisation"""
+        test_data = [
+            TimeRange.from_str("[100:0_0:0]"),
+            TimeRange.from_str("[10:0_10:0)"),
+            TimeRange.from_str("(10:0_10:0]"),
+        ]
+
+        for tr in test_data:
+            with self.subTest(tr=tr):
+                self.assertEqual(tr.start, TimeRange.never().start)
+                self.assertEqual(tr.end, TimeRange.never().end)
+                self.assertEqual(tr.inclusivity, TimeRange.never().inclusivity)
+
+    def test_eternity_normalise(self):
+        """Check 'eternity' normalisation"""
+        tr = TimeRange(None, None, TimeRange.EXCLUSIVE)
+        self.assertEqual(tr.inclusivity, TimeRange.INCLUSIVE)


### PR DESCRIPTION
This avoids invalid database lookups in Squirrel when requesting a time range of flow segments such as `[10:0_5:0)`.

Inspiration from python `range()` to produce `[]` (~ TimeRange.never()) when start > end rather than raise an ValueError.

Pivotal: https://www.pivotaltracker.com/story/show/170947695