### PR TITLE
Require later python version 3, >= 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediatimestamp Changelog
 
+## 1.7.2
+- Require Python version 3.6 rather than 3.
+
 ## 1.7.1
 - Correct inclusivity names in `timerange_between` method.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,15 @@ pipeline {
     environment {
         http_proxy = "http://www-cache.rd.bbc.co.uk:8080"
         https_proxy = "http://www-cache.rd.bbc.co.uk:8080"
+        PATH = "$HOME/.pyenv/bin:$PATH"
     }
     stages {
+        stage("Ensure pyenv has python3.6.8") {
+            steps {
+                sh "pyenv install -s 3.6.8"
+                sh "pyenv local 3.6.8"
+            }
+        }
         stage ("Parallel Jobs") {
             parallel {
                 stage ("Linting Check") {

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '1.7.1'
+version = '1.7.2'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py3
+envlist = py27, py36
 
 [testenv]
 commands = python -m unittest discover -s tests


### PR DESCRIPTION
`from hypothesis.strategies import integers, lists` failed in Python 3.5, #42, because of a bug: https://github.com/altair-viz/altair/issues/972.

Pivotal: https://www.pivotaltracker.com/story/show/170947695