### PR TITLE
Add timerange_before and timerange_after methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # mediatimestamp Changelog
 
+# 2.5.0
+- Add `timerange_before` and `timerange_after` methods to TimeRange.
 
 # 2.4.0
 - Allow hashing of TimeRanges

--- a/mediatimestamp/immutable/timerange.py
+++ b/mediatimestamp/immutable/timerange.py
@@ -667,6 +667,30 @@ class TimeRange (object):
                 inclusivity |= TimeRange.INCLUDE_START
             return TimeRange(other.end, self.start, inclusivity)
 
+    def timerange_before(self) -> "TimeRange":
+        """Returns the time range before the start of the this one"""
+        if self.start is None:
+            return TimeRange.never()
+
+        if self.includes_start():
+            inclusivity = TimeRange.EXCLUSIVE
+        else:
+            inclusivity = TimeRange.INCLUDE_END
+
+        return TimeRange.from_end(self.start, inclusivity=inclusivity)
+
+    def timerange_after(self) -> "TimeRange":
+        """Returns the time range after the end of the this one"""
+        if self.end is None:
+            return TimeRange.never()
+
+        if self.includes_end():
+            inclusivity = TimeRange.EXCLUSIVE
+        else:
+            inclusivity = TimeRange.INCLUDE_START
+
+        return TimeRange.from_start(self.end, inclusivity=inclusivity)
+
     def is_empty(self) -> bool:
         """Returns true on any empty range."""
         return (self.start is not None and

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 # Basic metadata
 name = 'mediatimestamp'
-version = '2.4.1'
+version = '2.5.0'
 description = 'A timestamp library for high precision nanosecond timestamps'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediatimestamp'
 author = 'James P. Weaver'

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -671,6 +671,32 @@ class TestTimeRange (unittest.TestCase):
                 self.assertEqual(left.timerange_between(right), expected)
                 self.assertEqual(right.timerange_between(left), expected)
 
+    def test_timerange_before(self):
+        test_data = [
+            (TimeRange.from_str("[0:0_10:0)"), TimeRange.from_str("_0:0)")),
+            (TimeRange.from_str("(0:0_10:0)"), TimeRange.from_str("_0:0]")),
+            (TimeRange.from_str("_10:0]"), TimeRange.never()),
+            (TimeRange.from_str("_"), TimeRange.never()),
+        ]
+
+        for (tr, expected) in test_data:
+            with self.subTest(tr=tr, expected=expected):
+                self.assertEqual(tr.timerange_before(), expected)
+                self.assertEqual(tr.timerange_before(), expected)
+
+    def test_timerange_after(self):
+        test_data = [
+            (TimeRange.from_str("[0:0_10:0)"), TimeRange.from_str("[10:0_")),
+            (TimeRange.from_str("[0:0_10:0]"), TimeRange.from_str("(10:0_")),
+            (TimeRange.from_str("[0:0_"), TimeRange.never()),
+            (TimeRange.from_str("_"), TimeRange.never()),
+        ]
+
+        for (tr, expected) in test_data:
+            with self.subTest(tr=tr, expected=expected):
+                self.assertEqual(tr.timerange_after(), expected)
+                self.assertEqual(tr.timerange_after(), expected)
+
     def test_normalise(self):
         tests_tr = [
             (TimeRange.from_str("[0:0_1:0)"), Fraction(25, 1), TimeRange.ROUND_NEAREST,


### PR DESCRIPTION
Named it `timerange_before`/`timerange_after` rather than `range_before`/`range_after` to be consistent with the names of other methods.
 
Pivotal: https://www.pivotaltracker.com/story/show/172955783