### PR TITLE
commontooling update

### DIFF
--- a/Dockerfile_multi.j2
+++ b/Dockerfile_multi.j2
@@ -9,7 +9,7 @@
 
 {{ macros.tests(modname) }}
 
-{{ macros.unittest(modname) }}
+{{ macros.unittestforpackage(modname) }}
 
 {{ macros.flake8(modname) }}
 

--- a/static-commontooling/docker/Dockerfile_multi_macros.j2
+++ b/static-commontooling/docker/Dockerfile_multi_macros.j2
@@ -90,6 +90,33 @@ ENTRYPOINT ["python", "-m", "unittest"]
 CMD ["discover", "tests", "-v"]
 {%- endmacro %}
 
+{% macro unittestforpackage(modname) -%}
+###############################################################################
+# Stage: unittest for packages
+###############################################################################
+FROM tests AS unittest
+WORKDIR /{{ modname }}/
+
+# Set the default command
+ENTRYPOINT ["python", "-m", "unittest"]
+CMD ["-v"]
+{%- endmacro %}
+
+{% macro unittestforpackagewithapi(modname) -%}
+###############################################################################
+# Stage: unittest for packages with COPY api
+###############################################################################
+FROM tests AS unittest
+WORKDIR /{{ modname }}/
+
+# Copy api in from the image built for that purpose
+COPY --from=api /api /api
+
+# Set the default command
+ENTRYPOINT ["python", "-m", "unittest"]
+CMD ["-v"]
+{%- endmacro %}
+
 {% macro flake8(modname) -%}
 ###############################################################################
 # Stage: flake8


### PR DESCRIPTION
# Details
Should the macro `unittestforpackage` be renamed to just `unittest` (and `unittestforpackagewithapi` to `unittestwithapi`)?

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
