### PR TITLE
TimeRange: Add test (and fix code) for infinite timeranges.

### DIFF
--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -889,6 +889,7 @@ class TestTimeRange (unittest.TestCase):
     # 2. Where the sub-chunks are shorter but not an exact division (i.e. there will be one short chunk at the end).
     # 3. Where the sub-chunk is exactly the length of the main timerange.
     # 4. Where the sub-chunk is longer than the timerange.
+    # 5. Where the timerange is infinite, our generator works.
     # All of which will need to follow the inclusivity rules.
     def test_into_chunks__shorter_line_up(self):
         """Test into_chunks when the sub-chunks are shorter than the main timerange and line up perfectly."""
@@ -942,3 +943,19 @@ class TestTimeRange (unittest.TestCase):
         tc4 = chunking_timerange.into_chunks(tc4_chunk)
         tc4_results = [time_range for time_range in tc4]
         self.assertEqual(tc3_4_expected, tc4_results)
+
+    def test_into_chunks__infinity(self):
+        """Test into_chunks when the timerange has no end."""
+        chunking_timerange = TimeRange.from_start(Timestamp.from_nanosec(0))
+        tc5_chunk = TimeOffset.from_str("30:0")
+        tc5_expected = [
+            TimeRange.from_str("[0:0_30:0)"),
+            TimeRange.from_str("[30:0_60:0)"),
+            TimeRange.from_str("[60:0_90:0)"),
+            TimeRange.from_str("[90:0_120:0)"),
+        ]
+        tc5 = chunking_timerange.into_chunks(tc5_chunk)
+        tc5_results = []
+        for i in range(4):
+            tc5_results.append(next(tc5))
+        self.assertEqual(tc5_expected, tc5_results)


### PR DESCRIPTION
# Details
A follow up to https://github.com/bbc/rd-apmm-python-lib-mediatimestamp/pull/63 -- I had a vision that I hadn't tested infinite timeranges in the chunker and that was indeed correct.

Done that, found an issue, fixed it.

# Pivotal Story
Story URL:

# Related PRs
https://github.com/bbc/rd-apmm-python-lib-mediatimestamp/pull/63

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [x] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
