### PR TITLE
Add caretaker stage to jenkinsfile

### DIFF
--- a/Jenkinsfile.json
+++ b/Jenkinsfile.json
@@ -2,6 +2,7 @@
     "docker": true,
     "stages": [
         "@setup",
+        "@caretaker",
         "@make check-static-files",
         "@make lint",
         "@make mypy",


### PR DESCRIPTION
# Details
Add caretaker stage to jenkinsfile

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/181382051

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
