### PR TITLE
Fix linting failures

### DIFF
--- a/mediatimestamp/time_value_range.py
+++ b/mediatimestamp/time_value_range.py
@@ -677,7 +677,7 @@ class TimeValueRange(Reversible[TimeValue]):
         elif not other.bounded_before() or cast(TimeValue, other.start) not in self:
             return TimeValueRange.never()
         else:
-            assert(isinstance(other.start, TimeValue))
+            assert (isinstance(other.start, TimeValue))
             if other.includes_start():
                 return self.split_at(other.start)[0]
             else:


### PR DESCRIPTION
# Details
Fixes lint failure that comes up in newer versions of flake8 because spaces are now required after keywords

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/182866165

# Related PRs
N/A

# Links to external test runs/working deployment
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [X] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
