### PR TITLE
Add to_float timestamp methods and further support to negative timestamps

### DIFF
--- a/mediatimestamp/__main__.py
+++ b/mediatimestamp/__main__.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':  # pragma: no cover
         print("ips-tai-nsec     {}".format(ts.to_tai_sec_nsec()))
         print("ips-tai-frac     {}".format(ts.to_tai_sec_frac()))
         print("utc              {}".format(ts.to_iso8601_utc()))
-        print("utc-secs         {}".format(ts.to_utc()[0]))
+        print("utc-secs         {}".format(ts.to_unix()[0]))
         print("smpte time label {}".format(ts.to_smpte_timelabel(50, 1)))
         sys.exit(0)
 

--- a/mediatimestamp/immutable/timestamp.py
+++ b/mediatimestamp/immutable/timestamp.py
@@ -405,6 +405,11 @@ class Timestamp(object):
     def to_tai_sec_frac(self, fixed_size: bool = False) -> str:
         return self.to_sec_frac(fixed_size=fixed_size)
 
+    def to_float(self) -> float:
+        """ Convert to a floating point number of seconds
+        """
+        return self._value / Timestamp.MAX_NANOSEC
+
     def to_datetime(self) -> datetime:
         sec, nsec, leap = self.to_unix()
         microsecond = int(round(nsec/1000))
@@ -436,6 +441,15 @@ class Timestamp(object):
         """ Wrapper of to_unix for back-compatibility.
         """
         return self.to_unix()
+
+    def to_unix_float(self) -> float:
+        """ Convert to unix seconds since the epoch as a floating point number
+        """
+        if self._value < 0:
+            return self.to_float()
+        else:
+            (sec, ns, _) = self.to_unix()
+            return sec + ns / Timestamp.MAX_NANOSEC
 
     def to_iso8601_utc(self) -> str:
         """ Get printed representation in ISO8601 format (UTC)

--- a/mediatimestamp/immutable/timestamp.py
+++ b/mediatimestamp/immutable/timestamp.py
@@ -148,7 +148,12 @@ class Timestamp(object):
     @classmethod
     def get_time(cls) -> "Timestamp":
         unix_time = time.time()
-        return cls.from_unix(int(unix_time), int(unix_time*cls.MAX_NANOSEC) - int(unix_time)*cls.MAX_NANOSEC)
+        abs_unix_time = abs(unix_time)
+        unix_sec = int(abs_unix_time)
+        unix_ns = int(abs_unix_time*cls.MAX_NANOSEC) - int(abs_unix_time)*cls.MAX_NANOSEC
+        unix_sign = 1 if unix_time >= 0 else -1
+
+        return cls.from_unix(unix_sec, unix_ns, unix_sign=unix_sign)
 
     @classmethod
     @deprecated(version="4.0.0",
@@ -238,10 +243,18 @@ class Timestamp(object):
     def from_datetime(cls, dt: datetime) -> "Timestamp":
         minTs = datetime.fromtimestamp(0, tz.gettz('UTC'))
         utcdt = dt.astimezone(tz.gettz('UTC'))
-        seconds = int((utcdt - minTs).total_seconds())
+        seconds = abs(int((utcdt - minTs).total_seconds()))
         nanoseconds = utcdt.microsecond * 1000
+        if utcdt < minTs:
+            sign = -1
+            if nanoseconds > 0:
+                # The microseconds was for a positive date-time. In a negative
+                # unix time it needs to be flipped.
+                nanoseconds = cls.MAX_NANOSEC - nanoseconds
+        else:
+            sign = 1
 
-        return cls.from_unix(seconds, nanoseconds, False)
+        return cls.from_unix(unix_sec=seconds, unix_ns=nanoseconds, unix_sign=sign, is_leap=False)
 
     @classmethod
     def from_iso8601_utc(cls, iso8601utc: str) -> "Timestamp":
@@ -250,7 +263,18 @@ class Timestamp(object):
         year, month, day, hour, minute, second, ns = _parse_iso8601(iso8601utc[:-1])
         gmtuple = (year, month, day, hour, minute, second - (second == 60))
         secs_since_epoch = calendar.timegm(gmtuple)
-        return cls.from_unix(secs_since_epoch, ns, (second == 60))
+        if secs_since_epoch < 0:
+            sign = -1
+            secs_since_epoch = abs(secs_since_epoch)
+            if ns > 0:
+                # The ns parsed from the timestamp was for a positive ISO 8601 date-time. In a negative
+                # unix time it needs to be flipped.
+                ns = cls.MAX_NANOSEC - ns
+                secs_since_epoch -= 1
+        else:
+            sign = 1
+
+        return cls.from_unix(unix_sec=secs_since_epoch, unix_ns=ns, unix_sign=sign, is_leap=(second == 60))
 
     @classmethod
     def from_smpte_timelabel(cls, timelabel: str) -> "Timestamp":
@@ -319,19 +343,16 @@ class Timestamp(object):
         return cls(ns=ns, sign=sign)
 
     @classmethod
-    def from_unix(cls, unix_sec: int, unix_ns: int, is_leap: bool = False) -> "Timestamp":
+    def from_unix(cls, unix_sec: int, unix_ns: int, unix_sign: int = 1, is_leap: bool = False) -> "Timestamp":
         leap_sec = 0
-        for tbl_sec, tbl_tai_sec_minus_1 in UTC_LEAP:
-            if unix_sec >= tbl_sec:
-                leap_sec = (tbl_tai_sec_minus_1 + 1) - tbl_sec
-                break
-        return cls(sec=unix_sec+leap_sec+is_leap, ns=unix_ns)
-
-    @classmethod
-    def from_utc(cls, utc_sec: int, utc_ns: int, is_leap: bool = False) -> "Timestamp":
-        """ Wrapper of from_unix for back-compatibility.
-        """
-        return cls.from_unix(utc_sec, utc_ns, is_leap)
+        if unix_sign >= 0:
+            for tbl_sec, tbl_tai_sec_minus_1 in UTC_LEAP:
+                if unix_sec + is_leap >= tbl_sec:
+                    leap_sec = (tbl_tai_sec_minus_1 + 1) - tbl_sec
+                    break
+        else:
+            is_leap = False
+        return cls(sec=unix_sec+leap_sec, ns=unix_ns, sign=unix_sign)
 
     def is_null(self) -> bool:
         return self._value == 0
@@ -411,55 +432,61 @@ class Timestamp(object):
         return self._value / Timestamp.MAX_NANOSEC
 
     def to_datetime(self) -> datetime:
-        sec, nsec, leap = self.to_unix()
+        sec, nsec, sign, leap = self.to_unix()
         microsecond = int(round(nsec/1000))
         if microsecond > 999999:
             sec += 1
             microsecond = 0
-        dt = datetime.fromtimestamp(sec, tz.gettz('UTC'))
+        if sign < 0 and microsecond > 0:
+            # The microseconds is for a negative unix time. In a positive date-time
+            # it needs to be flipped.
+            microsecond = 1000000 - microsecond
+            sec += 1
+        dt = datetime.fromtimestamp(sign * sec, tz.gettz('UTC'))
         dt = dt.replace(microsecond=microsecond)
 
         return dt
 
-    def to_unix(self) -> Tuple[int, int, bool]:
+    def to_unix(self) -> Tuple[int, int, int, bool]:
         """ Convert to unix seconds.
         Returns a tuple of (seconds, nanoseconds, is_leap), where `is_leap` is
         `True` when the input time corresponds exactly to a UTC leap second.
         Note that this deliberately returns a tuple, to try and avoid confusion.
         """
-        leap_sec = 0
-        is_leap = False
-        for unix_sec, tai_sec_minus_1 in UTC_LEAP:
-            if self.sec >= tai_sec_minus_1:
-                leap_sec = (tai_sec_minus_1 + 1) - unix_sec
-                is_leap = self.sec == tai_sec_minus_1
-                break
+        if self._value < 0:
+            return (self.sec, self.ns, self.sign, False)
+        else:
+            leap_sec = 0
+            is_leap = False
+            for unix_sec, tai_sec_minus_1 in UTC_LEAP:
+                if self.sec >= tai_sec_minus_1:
+                    leap_sec = (tai_sec_minus_1 + 1) - unix_sec
+                    is_leap = self.sec == tai_sec_minus_1
+                    break
 
-        return (self.sec - leap_sec, self.ns, is_leap)
-
-    def to_utc(self) -> Tuple[int, int, bool]:
-        """ Wrapper of to_unix for back-compatibility.
-        """
-        return self.to_unix()
+            return (self.sec - leap_sec, self.ns, self.sign, is_leap)
 
     def to_unix_float(self) -> float:
         """ Convert to unix seconds since the epoch as a floating point number
         """
-        if self._value < 0:
-            return self.to_float()
-        else:
-            (sec, ns, _) = self.to_unix()
-            return sec + ns / Timestamp.MAX_NANOSEC
+        (sec, ns, sign, _) = self.to_unix()
+        return sign * (sec + ns / Timestamp.MAX_NANOSEC)
 
     def to_iso8601_utc(self) -> str:
         """ Get printed representation in ISO8601 format (UTC)
         YYYY-MM-DDThh:mm:ss.s
         where `s` is fractional seconds at nanosecond precision (always 9-chars wide)
         """
-        unix_s, unix_ns, is_leap = self.to_unix()
-        utc_bd = time.gmtime(unix_s)
-        frac_sec = self._get_fractional_seconds(fixed_size=True)
+        unix_s, unix_ns, unix_sign, is_leap = self.to_unix()
+        if unix_sign < 0 and unix_ns > 0:
+            # The nanoseconds is for a negative unix time. In a positive ISO 8601 date-time
+            # it needs to be flipped.
+            unix_ns = Timestamp.MAX_NANOSEC - unix_ns
+            unix_s += 1
+        utc_bd = time.gmtime(unix_sign * unix_s)
+        frac_sec = Timestamp(ns=unix_ns)._get_fractional_seconds(fixed_size=True)
         leap_sec = int(is_leap)
+
         return '%04d-%02d-%02dT%02d:%02d:%02d.%sZ' % (utc_bd.tm_year,
                                                       utc_bd.tm_mon,
                                                       utc_bd.tm_mday,
@@ -481,7 +508,7 @@ class Timestamp(object):
         count_on_or_after_second = Timestamp(tai_seconds, 0).to_count(rate, rounding=self.ROUND_UP)
         count_within_second = count - count_on_or_after_second
 
-        unix_sec, unix_ns, is_leap = normalised_ts.to_unix()
+        unix_sec, unix_ns, unix_sign, is_leap = normalised_ts.to_unix()
         leap_sec = int(is_leap)
 
         if utc_offset is None:

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -277,6 +277,22 @@ class TestTimestamp(unittest.TestCase):
                 self.assertEqual(r, case[1],
                                  msg="Timestamp.from_float{!r} == {!r}, expected {!r}".format(case[0], r, case[1]))
 
+    def test_to_float(self):
+        """This tests that timestamps can be created from a float."""
+        cases = [
+            ((float(1.0)), Timestamp(1, 0)),
+            ((float(1_000_000_000)), Timestamp(1_000_000_000, 0)),
+            ((float(2.76)), Timestamp(2, 760_000_000)),
+            ((float(-3.14)), Timestamp(3, 140_000_000, -1)),
+            ((float(0.02)), Timestamp(0, 20_000_000))
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                r = case[1].to_float()
+                self.assertEqual(r, case[1],
+                                 msg="{!r},to_float() == {!r}, expected {!r}".format(case[1], r, case[0]))
+
     def test_set_value(self):
         """This tests that timestamps cannot have their value set."""
         tests_ts = [
@@ -879,3 +895,23 @@ class TestTimestamp(unittest.TestCase):
 
         for t in tests:
             self.assertEqual(t[0].get_leap_seconds(), t[1])
+
+    def test_to_unix(self):
+        tests = [
+            (Timestamp(63072008, 999999999), (63072008, 999999999, False)),  # 0 leap seconds
+            (Timestamp(63072009, 0), (63071999, 0, True)),  # 10 leap seconds at leap
+            (Timestamp(1512491629, 0), (1512491592, 0, False)),  # 37 leap seconds
+        ]
+
+        for t in tests:
+            self.assertEqual(t[0].to_unix(), t[1])
+
+    def test_to_unix_float(self):
+        tests = [
+            (Timestamp(63072008, 999999999), 63072008 + 999999999 / 1000000000),
+            (Timestamp(63072009, 0), 63071999),
+            (Timestamp(1000, 0, -1), -1000)
+        ]
+
+        for t in tests:
+            self.assertEqual(t[0].to_unix_float(), t[1])


### PR DESCRIPTION
# Details
This PR
* adds `Timestamp.to_float` and `Timestamp.to_unix_float` methods
* removes deprecated `Timestamp.to_utc`
  * Only the Squirrel garbage collector layer uses this method and it is updated in https://github.com/bbc/rd-cloudfit-squirrel-media-store/pull/513
* Changed `Timestamp.to_unix` to return the sign as well in the tuple result
* supports conversion between negative Timestamp and datetime and iso8601
* fixes `Timestamp.from_unix` when `is_leap` is True

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/187046592

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
