### PR TITLE
Fix TimeRange `__contains__` and add Timestamp `__float__`

### DIFF
--- a/mediatimestamp/immutable/timerange.py
+++ b/mediatimestamp/immutable/timerange.py
@@ -372,15 +372,8 @@ class TimeRange (object):
 
     def __contains__(self, ts: object) -> bool:
         """Returns true if the timestamp is within this range."""
-        return ((isinstance(ts, SupportsMediaTimestamp)) and
-                (self.start is None or mediatimestamp(ts) >= self.start) and
-                (self.end is None or mediatimestamp(ts) <= self.end) and
-                (not ((self.start is not None) and
-                      (mediatimestamp(ts) == self.start) and
-                      (self.inclusivity & TimeRange.INCLUDE_START == 0))) and
-                (not ((self.end is not None) and
-                      (mediatimestamp(ts) == self.end) and
-                      (self.inclusivity & TimeRange.INCLUDE_END == 0))))
+        return (isinstance(ts, (Timestamp, SupportsMediaTimestamp, int, float)) and
+                self.contains_subrange(mediatimestamp(ts)))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SupportsMediaTimeRange):

--- a/mediatimestamp/immutable/timerange.py
+++ b/mediatimestamp/immutable/timerange.py
@@ -371,9 +371,13 @@ class TimeRange (object):
         return (self.start is not None and self.end is not None)
 
     def __contains__(self, ts: object) -> bool:
-        """Returns true if the timestamp is within this range."""
-        return (isinstance(ts, (Timestamp, SupportsMediaTimestamp, int, float)) and
-                self.contains_subrange(mediatimestamp(ts)))
+        """Returns true if the timestamp or timerange is wholly within this range."""
+        return ((
+                    isinstance(ts, (Timestamp, SupportsMediaTimestamp, int, float)) and
+                    self.contains_subrange(mediatimestamp(ts))
+                ) or (
+                    isinstance(ts, (TimeRange, SupportsMediaTimeRange)) and
+                    self.contains_subrange(ts)))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SupportsMediaTimeRange):

--- a/mediatimestamp/immutable/timestamp.py
+++ b/mediatimestamp/immutable/timestamp.py
@@ -429,7 +429,7 @@ class Timestamp(object):
     def to_float(self) -> float:
         """ Convert to a floating point number of seconds
         """
-        return self._value / Timestamp.MAX_NANOSEC
+        return self.__float__()
 
     def to_datetime(self) -> datetime:
         sec, nsec, sign, leap = self.to_unix()
@@ -664,6 +664,9 @@ class Timestamp(object):
     def __floordiv__(self, anint: int) -> "Timestamp":
         ns = self._value // anint
         return Timestamp(ns=ns)
+
+    def __float__(self):
+        return self._value / Timestamp.MAX_NANOSEC
 
     def _get_fractional_seconds(self, fixed_size: bool = False) -> str:
         div = self.MAX_NANOSEC // 10

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -369,9 +369,17 @@ class TestTimeRange (unittest.TestCase):
         self.assertNotIn(None, TimeRange.from_str("[0:0]"))
         self.assertNotIn(None, TimeRange.never())
         self.assertNotIn(None, TimeRange.eternity())
+
         self.assertNotIn(1.0, TimeRange.from_str("[0:0]"))
         self.assertIn(1.0, TimeRange.from_str("[1:0]"))
         self.assertIn(1.0, TimeRange.from_str("[0:0_10:0)"))
+
+        self.assertNotIn(Timestamp.from_str("0:0"), TimeRange.from_str("[1:0_10:0)"))
+        self.assertIn(Timestamp.from_str("1:0"), TimeRange.from_str("[1:0_10:0)"))
+
+        self.assertNotIn(TimeRange.from_str("[0:0_10:0)"), TimeRange.from_str("[0:0_5:0)"))
+        self.assertIn(TimeRange.from_str("0:0_5:0"), TimeRange.from_str("[0:0_10:0)"))
+
         # The subrange tests will cover the rest
 
     def _check_intersection(self, a, b, c, d):

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -489,6 +489,11 @@ class TestTimeRange (unittest.TestCase):
 
         self._check_length(a, b, c)
 
+    def test_length_float(self):
+        self.assertEqual(TimeRange.eternity().length, float("inf"))
+        self.assertEqual(float(TimeRange.eternity().length), float("inf"))
+        self.assertEqual(float(TimeRange.from_str("[0:0_1:0)").length), 1.0)
+
     def test_repr(self):
         """This tests that the repr function turns time ranges into `eval`-able strings."""
         test_trs = [

--- a/tests/test_timerange.py
+++ b/tests/test_timerange.py
@@ -353,6 +353,27 @@ class TestTimeRange (unittest.TestCase):
 
         self._check_subrange(a, b, c, d)
 
+    def test_subrange__eternity_never(self):
+        self.assertTrue(TimeRange.eternity().contains_subrange(TimeRange.eternity()))
+        self.assertTrue(TimeRange.eternity().contains_subrange(TimeRange.from_str("[0:0]")))
+        self.assertTrue(TimeRange.eternity().contains_subrange(TimeRange.from_str("[0:0_1:0)")))
+
+        self.assertTrue(TimeRange.eternity().contains_subrange(TimeRange.never()))
+
+        self.assertFalse(TimeRange.never().contains_subrange(TimeRange.eternity()))
+        self.assertFalse(TimeRange.never().contains_subrange(TimeRange.never()))
+        self.assertFalse(TimeRange.never().contains_subrange(TimeRange.from_str("[0:0]")))
+        self.assertFalse(TimeRange.never().contains_subrange(TimeRange.from_str("[0:0_1:0)")))
+
+    def test_contains(self):
+        self.assertNotIn(None, TimeRange.from_str("[0:0]"))
+        self.assertNotIn(None, TimeRange.never())
+        self.assertNotIn(None, TimeRange.eternity())
+        self.assertNotIn(1.0, TimeRange.from_str("[0:0]"))
+        self.assertIn(1.0, TimeRange.from_str("[1:0]"))
+        self.assertIn(1.0, TimeRange.from_str("[0:0_10:0)"))
+        # The subrange tests will cover the rest
+
     def _check_intersection(self, a, b, c, d):
         self.assertEqual(TimeRange(a, c, TimeRange.INCLUDE_START).intersect_with(b), mediatimerange(b))
 


### PR DESCRIPTION
# Details
This PR:
* Fixes `TimeRange.__contains__` which wrongly returned `False` for `TimeRange.from_str("[0:0_1:0)") in TimeRange.eternity()` for example.
* Adds support for TimeRange arg to `TimeRange.__contains__`, which is equivalent to using `contains_subrange`.
* Adds a `Timestamp.__float__` which simplifies and avoids typing issues when converting a `TimeRange.length` to a `float`.

# Jira Issue
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5398

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Jira Issue
- [ ] Follow-up stories added to Jira
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
